### PR TITLE
Add new parameter 'aws_region' for builtin tools "apply_guardrail"

### DIFF
--- a/builtin_tools/aws/tools/apply_guardrail.py
+++ b/builtin_tools/aws/tools/apply_guardrail.py
@@ -1,7 +1,6 @@
 import boto3
 import json
 import logging
-import requests
 from typing import Any, Union
 from pydantic import BaseModel, Field
 from botocore.exceptions import BotoCoreError
@@ -12,21 +11,12 @@ from core.tools.tool.builtin_tool import BuiltinTool
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-def get_current_region():
-    try:
-        response = requests.get('http://169.254.169.254/latest/meta-data/placement/region', timeout=1)
-        if response.status_code == 200:
-            return response.text
-    except requests.RequestException:
-        logger.warning("Unable to retrieve region from EC2 metadata. Falling back to default.")
-    return "us-east-1"  # Default region if unable to retrieve
-
 class GuardrailParameters(BaseModel):
     guardrail_id: str = Field(..., description="The identifier of the guardrail")
     guardrail_version: str = Field(..., description="The version of the guardrail")
     source: str = Field(..., description="The source of the content")
     text: str = Field(..., description="The text to apply the guardrail to")
-    aws_region: str = Field(default_factory=get_current_region, description="AWS region for the Bedrock client")
+    aws_region: str = Field(..., description="AWS region for the Bedrock client")
 
 class ApplyGuardrailTool(BuiltinTool):
     def _invoke(self,

--- a/builtin_tools/aws/tools/apply_guardrail.py
+++ b/builtin_tools/aws/tools/apply_guardrail.py
@@ -1,6 +1,7 @@
 import boto3
 import json
 import logging
+import requests
 from typing import Any, Union
 from pydantic import BaseModel, Field
 from botocore.exceptions import BotoCoreError

--- a/builtin_tools/aws/tools/apply_guardrail.yaml
+++ b/builtin_tools/aws/tools/apply_guardrail.yaml
@@ -54,3 +54,14 @@ parameters:
       zh_Hans: 用于请求护栏审查的内容，可以是用户输入或 LLM 输出。
     llm_description: The content used for requesting guardrail review, which can be either user input or LLM output.
     form: llm
+  - name: aws_region
+    type: string
+    required: true
+    label:
+      en_US: AWS Region
+      zh_Hans: AWS 区域
+    human_description:
+      en_US: Please enter the AWS region for the Bedrock client, for example 'us-east-1'.
+      zh_Hans: 请输入 Bedrock 客户端的 AWS 区域，例如 'us-east-1'。
+    llm_description: Please enter the AWS region for the Bedrock client, for example 'us-east-1'.
+    form: form


### PR DESCRIPTION
Title: Add new parameter 'aws_region' for builtin tools "apply_guardrail"

Description:
This PR adds a new parameter 'aws_region' to allow users to specify AWS regions when using the tool.

Changes:
- Introduced 'aws regions' parameter
- Updated relevant functions to utilize this parameter

Please review the implementation and usage of the new parameter.
