### PR TITLE
support bedrock inference profile

### DIFF
--- a/plugins/bedrock/provider/bedrock.py
+++ b/plugins/bedrock/provider/bedrock.py
@@ -1,5 +1,7 @@
 import logging
 from collections.abc import Mapping
+import boto3
+from botocore.exceptions import ClientError
 
 from dify_plugin import ModelProvider
 from dify_plugin.entities.model import ModelType
@@ -26,3 +28,110 @@ class AmazonBedrockModelProvider(ModelProvider):
         except Exception as ex:
             logger.exception(f"{self.get_provider_schema().provider} credentials validate failed")
             raise ex
+
+    def validate_model_credentials(self, model: str, model_type: ModelType, credentials: Mapping) -> None:
+        """
+        Validate model credentials for custom models (inference profiles)
+        
+        :param model: model name
+        :param model_type: model type
+        :param credentials: model credentials
+        """
+        try:
+            if model_type == ModelType.LLM:
+                # Check if this is an inference profile based custom model
+                inference_profile_id = credentials.get("inference_profile_id")
+                if inference_profile_id:
+                    # Validate inference profile
+                    self._validate_inference_profile(inference_profile_id, credentials)
+                else:
+                    # Fallback to regular model validation
+                    model_instance = self.get_model_instance(model_type)
+                    model_instance.validate_credentials(model=model, credentials=credentials)
+            else:
+                # For non-LLM types, use regular validation
+                model_instance = self.get_model_instance(model_type)
+                model_instance.validate_credentials(model=model, credentials=credentials)
+        except CredentialsValidateFailedError as ex:
+            raise ex
+        except Exception as ex:
+            logger.exception(f"Model {model} credentials validate failed")
+            raise CredentialsValidateFailedError(str(ex))
+
+    def _validate_inference_profile(self, inference_profile_id: str, credentials: Mapping) -> None:
+        """
+        Validate inference profile by calling Bedrock API
+        
+        :param inference_profile_id: inference profile identifier
+        :param credentials: credentials containing AWS access info
+        """
+        try:
+            # Get AWS credentials
+            aws_access_key_id = credentials.get("aws_access_key_id")
+            aws_secret_access_key = credentials.get("aws_secret_access_key")
+            aws_region = credentials.get("aws_region", "us-east-1")
+            
+            # Create Bedrock client
+            session = boto3.Session(
+                aws_access_key_id=aws_access_key_id,
+                aws_secret_access_key=aws_secret_access_key,
+                region_name=aws_region
+            )
+            
+            bedrock_client = session.client('bedrock')
+            
+            # Call get-inference-profile API
+            response = bedrock_client.get_inference_profile(
+                inferenceProfileIdentifier=inference_profile_id
+            )
+            
+            # Check if profile is active
+            if response.get('status') != 'ACTIVE':
+                raise CredentialsValidateFailedError(f"Inference profile {inference_profile_id} is not active")
+                
+            logger.info(f"Successfully validated inference profile: {inference_profile_id}")
+            
+        except ClientError as e:
+            error_code = e.response['Error']['Code']
+            if error_code == 'ResourceNotFoundException':
+                raise CredentialsValidateFailedError(f"Inference profile {inference_profile_id} not found")
+            elif error_code == 'AccessDeniedException':
+                raise CredentialsValidateFailedError(f"Access denied to inference profile {inference_profile_id}")
+            else:
+                raise CredentialsValidateFailedError(f"Failed to validate inference profile: {str(e)}")
+        except Exception as e:
+            raise CredentialsValidateFailedError(f"Failed to validate inference profile: {str(e)}")
+
+    def get_inference_profile_info(self, inference_profile_id: str, credentials: Mapping) -> dict:
+        """
+        Get inference profile information from Bedrock API
+        
+        :param inference_profile_id: inference profile identifier
+        :param credentials: credentials containing AWS access info
+        :return: inference profile information
+        """
+        try:
+            # Get AWS credentials
+            aws_access_key_id = credentials.get("aws_access_key_id")
+            aws_secret_access_key = credentials.get("aws_secret_access_key")
+            aws_region = credentials.get("aws_region", "us-east-1")
+            
+            # Create Bedrock client
+            session = boto3.Session(
+                aws_access_key_id=aws_access_key_id,
+                aws_secret_access_key=aws_secret_access_key,
+                region_name=aws_region
+            )
+            
+            bedrock_client = session.client('bedrock')
+            
+            # Call get-inference-profile API
+            response = bedrock_client.get_inference_profile(
+                inferenceProfileIdentifier=inference_profile_id
+            )
+            
+            return response
+            
+        except Exception as e:
+            logger.error(f"Failed to get inference profile info: {str(e)}")
+            raise e

--- a/plugins/bedrock/provider/bedrock.yaml
+++ b/plugins/bedrock/provider/bedrock.yaml
@@ -19,6 +19,7 @@ supported_model_types:
   - rerank
 configurate_methods:
   - predefined-model
+  - customizable-model
 provider_credential_schema:
   credential_form_schemas:
     - variable: aws_access_key_id
@@ -167,6 +168,130 @@ models:
   text_embedding:
     predefined:
       - "models/text_embedding/*.yaml"
+model_credential_schema:
+  model:
+    label:
+      en_US: Model Name
+      zh_Hans: 模型名称
+    placeholder:
+      en_US: Enter your custom model name
+      zh_Hans: 输入自定义模型名称
+  credential_form_schemas:
+    - variable: inference_profile_id
+      show_on:
+        - variable: __model_type
+          value: llm
+      label:
+        en_US: Inference Profile ID
+        zh_Hans: 推理配置文件 ID
+      type: text-input
+      required: true
+      placeholder:
+        en_US: Enter your Bedrock Inference Profile ID (e.g., 0j6r4a8fn6ze)
+        zh_Hans: 输入您的 Bedrock 推理配置文件 ID
+      help:
+        text:
+          en_US: The unique identifier for your Bedrock Inference Profile
+          zh_Hans: Bedrock 推理配置文件的唯一标识符
+    - variable: context_length
+      show_on:
+        - variable: __model_type
+          value: llm
+      label:
+        en_US: Model Context Length
+        zh_Hans: 模型上下文长度
+      type: text-input
+      required: false
+      default: "4096"
+      placeholder:
+        en_US: Enter model context length (default 4096)
+        zh_Hans: 输入模型上下文长度（默认4096）
+    - variable: aws_access_key_id
+      required: false
+      label:
+        en_US: Access Key (If not provided, credentials are obtained from the running environment.)
+        zh_Hans: Access Key (如果未提供，凭证将从运行环境中获取。)
+      type: secret-input
+      placeholder:
+        en_US: Enter your Access Key
+        zh_Hans: 在此输入您的 Access Key
+    - variable: aws_secret_access_key
+      required: false
+      label:
+        en_US: Secret Access Key
+        zh_Hans: Secret Access Key
+      type: secret-input
+      placeholder:
+        en_US: Enter your Secret Access Key
+        zh_Hans: 在此输入您的 Secret Access Key
+    - variable: aws_region
+      required: false
+      label:
+        en_US: AWS Region
+        zh_Hans: AWS 地区
+      type: select
+      default: us-east-1
+      options:
+        - value: us-east-1
+          label:
+            en_US: US East (N. Virginia)
+            zh_Hans: 美国东部 (弗吉尼亚北部)
+        - value: us-east-2
+          label:
+            en_US: US East (Ohio)
+            zh_Hans: 美国东部 (俄亥俄)
+        - value: us-west-2
+          label:
+            en_US: US West (Oregon)
+            zh_Hans: 美国西部 (俄勒冈州)
+        - value: ap-south-1
+          label:
+            en_US: Asia Pacific (Mumbai)
+            zh_Hans: 亚太地区（孟买）
+        - value: ap-southeast-1
+          label:
+            en_US: Asia Pacific (Singapore)
+            zh_Hans: 亚太地区 (新加坡)
+        - value: ap-southeast-2
+          label:
+            en_US: Asia Pacific (Sydney)
+            zh_Hans: 亚太地区 (悉尼)
+        - value: ap-northeast-1
+          label:
+            en_US: Asia Pacific (Tokyo)
+            zh_Hans: 亚太地区 (东京)
+        - value: ap-northeast-2
+          label:
+            en_US: Asia Pacific (Seoul)
+            zh_Hans: 亚太地区（首尔）
+        - value: ca-central-1
+          label:
+            en_US: Canada (Central)
+            zh_Hans: 加拿大（中部）
+        - value: eu-central-1
+          label:
+            en_US: Europe (Frankfurt)
+            zh_Hans: 欧洲 (法兰克福)
+        - value: eu-west-1
+          label:
+            en_US: Europe (Ireland)
+            zh_Hans: 欧洲（爱尔兰）
+        - value: eu-west-2
+          label:
+            en_US: Europe (London)
+            zh_Hans: 欧洲西部 (伦敦)
+        - value: eu-west-3
+          label:
+            en_US: Europe (Paris)
+            zh_Hans: 欧洲（巴黎）
+        - value: sa-east-1
+          label:
+            en_US: South America (São Paulo)
+            zh_Hans: 南美洲（圣保罗）
+        - value: us-gov-west-1
+          label:
+            en_US: AWS GovCloud (US-West)
+            zh_Hans: AWS GovCloud (US-West)
 extra:
   python:
     provider_source: provider/bedrock.py


### PR DESCRIPTION
支持通过 Inference Profile ID 创建自定义模型

 添加自定义模型步骤：

1. 在 Bedrock 供应商配置页面，点击"添加模型"按钮
2. 填写以下信息：
   - **模型名称**: 为您的自定义模型起一个名字
   - **Inference Profile ID**: 输入您的 Profile ID（例如：`0j6r4a8fn6ze`）
   - **模型上下文长度**: 可选，默认为 4096
   - **AWS 认证信息**: 可选，如果不填写将使用供应商级别的配置