### PR TITLE
Use bedrock_client region for Bedrock model ARN to prevent cross-region reranking errors

### DIFF
--- a/builtin_tools/aws/tools/bedrock_retrieve.py
+++ b/builtin_tools/aws/tools/bedrock_retrieve.py
@@ -33,7 +33,8 @@ class BedrockRetrieveTool(BuiltinTool):
             }
 
             if rerank_model_id != "default":
-                model_for_rerank_arn = f"arn:aws:bedrock:us-west-2::foundation-model/{rerank_model_id}"
+                region = self.bedrock_client.meta.region_name
+                model_for_rerank_arn = f"arn:aws:bedrock:{region}::foundation-model/{rerank_model_id}"
                 rerankingConfiguration = {
                     "bedrockRerankingConfiguration": {
                         "numberOfRerankedResults": num_results,


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

This pull request updates the construction of the Bedrock model ARN in `builtin_tools/aws/tools/bedrock_retrieve.py` (line 36) to use the region from `bedrock_client` instead of the previously hardcoded `us-west-2`.

When running in a region different from `us-west-2`, using a hardcoded region causes the error:
"Reranking does not support cross-region calls. Please provide a valid model ARN."

By dynamically using `self.bedrock_client.meta.region_name` for the ARN's region, the reranking operation will always use the same region as the client, preventing cross-region errors and improving compatibility across different AWS regions.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
