### PR TITLE
[fix] Bedrock plugin: Fix TypeError when top_n is None in min(top_n, len(text_sources))

### DIFF
--- a/plugins/bedrock/models/rerank/rerank.py
+++ b/plugins/bedrock/models/rerank/rerank.py
@@ -72,7 +72,7 @@ class BedrockRerankModel(RerankModel):
         rerankingConfiguration = {
             "type": "BEDROCK_RERANKING_MODEL",
             "bedrockRerankingConfiguration": {
-                "numberOfResults": min(top_n, len(text_sources)),
+                "numberOfResults": min(len(text_sources) if top_n is None else top_n, len(text_sources)),
                 "modelConfiguration": {
                     "modelArn": model_package_arn,
                 },


### PR DESCRIPTION
min(top_n, len(text_sources)) - top_n might be int or NoneType. If it's NoneType or undefined, it could cause an error: 
` '<' not supported between instances of 'int' and 'NoneType'.`