### PR TITLE
Add AgentCore Memory tool for AWS Bedrock

### DIFF
--- a/plugins/aws_tools/tools/agentcore_memory.py
+++ b/plugins/aws_tools/tools/agentcore_memory.py
@@ -30,7 +30,7 @@ class AgentCoreMemoryTool(Tool):
     namespace: str = None
     
     def _initialize_memory_client(self, tool_parameters: dict[str, Any]) -> bool:
-        """Initialize Memory client with AWS credentials like bedrock_retrieve"""
+        """Initialize Memory client with AWS credentials """
         try:
             # Get AWS credentials from tool parameters
             aws_region = tool_parameters.get("aws_region")
@@ -41,7 +41,7 @@ class AgentCoreMemoryTool(Tool):
             region = aws_region or 'us-east-1'
             
             if AGENTCORE_SDK_AVAILABLE:
-                # Create client kwargs similar to bedrock_retrieve
+                # Create client kwargs 
                 client_kwargs = {"region_name": region}
                 
                 # Only add credentials if both access key and secret key are provided

--- a/plugins/aws_tools/tools/agentcore_memory.py
+++ b/plugins/aws_tools/tools/agentcore_memory.py
@@ -1,0 +1,387 @@
+import json
+import logging
+from collections.abc import Generator
+from typing import Any, Dict
+from dify_plugin import Tool
+from dify_plugin.entities.tool import ToolInvokeMessage
+
+# Import the base functionality
+import sys
+import os
+sys.path.append(os.path.dirname(os.path.abspath(__file__)))
+
+# Import AgentCore Memory SDK directly
+try:
+    from bedrock_agentcore.memory import MemoryClient
+    AGENTCORE_SDK_AVAILABLE = True
+except ImportError as e:
+    AGENTCORE_SDK_AVAILABLE = False
+    MemoryClient = None
+    print(f"Warning: bedrock-agentcore SDK import failed: {e}")
+
+logger = logging.getLogger(__name__)
+
+
+class AgentCoreMemoryTool(Tool):
+    memory_client: Any = None
+    memory_id: str = None
+    actor_id: str = None
+    session_id: str = None
+    namespace: str = None
+    
+    def _initialize_memory_client(self, tool_parameters: dict[str, Any]) -> bool:
+        """Initialize Memory client with AWS credentials like bedrock_retrieve"""
+        try:
+            # Get AWS credentials from tool parameters
+            aws_region = tool_parameters.get("aws_region")
+            aws_access_key_id = tool_parameters.get("aws_access_key_id")
+            aws_secret_access_key = tool_parameters.get("aws_secret_access_key")
+
+            # Initialize MemoryClient with region
+            region = aws_region or 'us-east-1'
+            
+            if AGENTCORE_SDK_AVAILABLE:
+                # Create client kwargs similar to bedrock_retrieve
+                client_kwargs = {"region_name": region}
+                
+                # Only add credentials if both access key and secret key are provided
+                if aws_access_key_id and aws_secret_access_key:
+                    # For MemoryClient, we need to set environment variables or use boto3 session
+                    import os
+                    os.environ['AWS_ACCESS_KEY_ID'] = aws_access_key_id
+                    os.environ['AWS_SECRET_ACCESS_KEY'] = aws_secret_access_key
+                    os.environ['AWS_REGION'] = region
+                
+                # Initialize MemoryClient without hardcoded credentials
+                self.memory_client = MemoryClient(region_name=region)
+                logger.info(f"Memory client initialized for region: {region}")
+                return True
+            else:
+                logger.error("AgentCore Memory SDK not available")
+                return False
+                
+        except Exception as e:
+            logger.error(f"Failed to initialize Memory client: {str(e)}")
+            return False
+    
+    def _get_runtime_config(self, key: str, default_value: str) -> str:
+        """Get configuration from runtime (AgentCore Memory Manager settings)"""
+        try:
+            # Try to get from runtime credentials/settings
+            if self.runtime and hasattr(self.runtime, 'credentials'):
+                credentials = self.runtime.credentials
+                if credentials and key in credentials:
+                    return credentials[key]
+            
+            # Fallback to default
+            return default_value
+        except Exception:
+            return default_value
+    
+    def _record_information(self, tool_parameters: dict[str, Any]) -> Generator[ToolInvokeMessage]:
+        """Record information to memory"""
+        try:
+            # Extract the information to record
+            information = tool_parameters.get('information', '')
+            
+            if not information:
+                yield self.create_text_message("Error: Information to record is required")
+                return
+            
+            # Use instance variables
+            memory_id = self.memory_id
+            actor_id = self.actor_id
+            session_id = self.session_id
+            
+            yield self.create_text_message(f"💾 Recording information for {actor_id}...")
+            
+            if self.memory_client:
+                # Format messages for storage - treat the information as a user message with assistant acknowledgment
+                messages = [
+                    (information, "USER"),
+                    ("Information recorded successfully.", "ASSISTANT")
+                ]
+                
+                # Store conversation event
+                result = self.memory_client.create_event(
+                    memory_id=memory_id,
+                    actor_id=actor_id,
+                    session_id=session_id,
+                    messages=messages
+                )
+                
+                # Extract event ID from result
+                event_id = "unknown"
+                if isinstance(result, dict):
+                    if 'event' in result:
+                        event_id = result['event'].get('eventId', 'unknown')
+                    elif 'eventId' in result:
+                        event_id = result['eventId']
+                
+                # Format response
+                response_data = {
+                    'success': True,
+                    'message': "Information recorded successfully",
+                    'data': {
+                        'event_id': event_id,
+                        'memory_id': memory_id,
+                        'actor_id': actor_id,
+                        'session_id': session_id,
+                        'information_length': len(information)
+                    }
+                }
+                
+                yield self.create_json_message(response_data)
+            else:
+                yield self.create_text_message("❌ AgentCore Memory SDK not available")
+                
+        except Exception as e:
+            logger.error(f"Record information error: {str(e)}")
+            yield self.create_text_message(f"Exception in record operation: {str(e)}")
+    
+    def _retrieve_history(self, tool_parameters: dict[str, Any]) -> Generator[ToolInvokeMessage]:
+        """Retrieve conversation history using get_last_k_turns"""
+        try:
+            # Extract business parameters
+            k = tool_parameters.get('max_results', 10)
+            
+            # Validate k (number of turns to retrieve)
+            if k < 1 or k > 50:
+                k = 10
+            
+            # Use instance variables
+            memory_id = self.memory_id
+            actor_id = self.actor_id
+            session_id = self.session_id
+            
+            yield self.create_text_message(f"📚 Retrieving last {k} conversation turns for {actor_id} (session: {session_id})")
+            
+            if self.memory_client:
+                # Retrieve last k conversation turns using get_last_k_turns
+                events = self.memory_client.get_last_k_turns(
+                    memory_id=memory_id,
+                    actor_id=actor_id,
+                    session_id=session_id,
+                    k=k
+                )
+                
+                # Format the events for better readability
+                formatted_events = []
+                
+                if events and isinstance(events, list):
+                    for i, event in enumerate(events):
+                        # Each event is actually a list of messages
+                        if isinstance(event, list):
+                            formatted_event = {
+                                'turn_number': i + 1,
+                                'event_id': f'turn_{i+1}',
+                                'timestamp': 'unknown',
+                                'messages': event  # event is already the list of messages
+                            }
+                        elif isinstance(event, dict):
+                            # Fallback for dict format
+                            formatted_event = {
+                                'turn_number': i + 1,
+                                'event_id': event.get('eventId', f'turn_{i+1}'),
+                                'timestamp': event.get('timestamp', 'unknown'),
+                                'messages': event.get('messages', [])
+                            }
+                        else:
+                            # Handle event objects with attributes
+                            formatted_event = {
+                                'turn_number': i + 1,
+                                'event_id': getattr(event, 'eventId', f'turn_{i+1}'),
+                                'timestamp': getattr(event, 'timestamp', 'unknown'),
+                                'messages': getattr(event, 'messages', [])
+                            }
+                        formatted_events.append(formatted_event)
+                
+                # Format response
+                response_data = {
+                    'success': True,
+                    'message': f"Retrieved last {len(formatted_events)} conversation turns successfully",
+                    'data': {
+                        'memory_id': memory_id,
+                        'actor_id': actor_id,
+                        'session_id': session_id,
+                        'turns_requested': k,
+                        'turns_retrieved': len(formatted_events),
+                        'conversation_turns': formatted_events
+                    }
+                }
+                
+                yield self.create_json_message(response_data)
+            else:
+                yield self.create_text_message("❌ AgentCore Memory SDK not available")
+                
+        except Exception as e:
+            logger.error(f"Retrieve history error: {str(e)}")
+            yield self.create_text_message(f"Exception in retrieve operation: {str(e)}")
+    
+    def _search_memories(self, tool_parameters: dict[str, Any]) -> Generator[ToolInvokeMessage]:
+        """Search for relevant memories"""
+        try:
+            # Extract business parameters
+            search_query = tool_parameters.get('search_query', '')
+            max_results = tool_parameters.get('max_results', 10)
+            
+            if not search_query:
+                yield self.create_text_message("Error: Search query is required")
+                return
+            
+            # Validate max_results
+            if max_results < 1 or max_results > 20:
+                max_results = 10
+            
+            # Use instance variables
+            memory_id = self.memory_id
+            actor_id = self.actor_id
+            namespace = self.namespace
+            
+            yield self.create_text_message(f"🔍 Searching memories for: '{search_query}'")
+            
+            if self.memory_client:
+                # Search memories using retrieve_memories method
+                result = self.memory_client.retrieve_memories(
+                    memory_id=memory_id,
+                    actor_id=actor_id,
+                    namespace=namespace,
+                    query=search_query,
+                    top_k=max_results
+                )
+                
+                # Extract memories from response
+                memories_list = result.get('memories', []) if isinstance(result, dict) else result
+                
+                # Ensure it's a list
+                if not isinstance(memories_list, list):
+                    memories_list = list(memories_list) if hasattr(memories_list, '__iter__') else []
+                
+                # Apply max_results limit if needed
+                if max_results and len(memories_list) > max_results:
+                    memories_list = memories_list[:max_results]
+                
+                # Process memories to ensure JSON serialization
+                processed_memories = []
+                for memory in memories_list:
+                    if isinstance(memory, dict):
+                        # Convert datetime objects to strings
+                        processed_memory = {}
+                        for key, value in memory.items():
+                            if hasattr(value, 'isoformat'):  # datetime object
+                                processed_memory[key] = value.isoformat()
+                            else:
+                                processed_memory[key] = value
+                        processed_memories.append(processed_memory)
+                    else:
+                        processed_memories.append(str(memory))
+                
+                # Format response with detailed information
+                response_data = {
+                    'success': True,
+                    'message': f"Found {len(processed_memories)} relevant memor(ies)",
+                    'data': {
+                        'memories_count': len(processed_memories),
+                        'memory_id': memory_id,
+                        'namespace': namespace,
+                        'query': search_query,
+                        'memories': processed_memories
+                    }
+                }
+                
+                # Create a formatted text response for better readability
+                try:
+                    formatted_response = f"tool response: {json.dumps(response_data, ensure_ascii=False, default=str)}"
+                    yield self.create_text_message(formatted_response)
+                except Exception as json_error:
+                    # Fallback to simple response if JSON serialization fails
+                    simple_response = f"Found {len(processed_memories)} memories for query: {search_query}"
+                    yield self.create_text_message(simple_response)
+            else:
+                yield self.create_text_message("❌ AgentCore Memory SDK not available")
+                
+        except Exception as e:
+            logger.error(f"Search memories error: {str(e)}")
+            yield self.create_text_message(f"Exception in search operation: {str(e)}")
+    
+    def validate_parameters(self, parameters: dict[str, Any]) -> None:
+        """
+        Validate the parameters
+        """
+        operation = parameters.get('operation')
+        if not operation:
+            raise ValueError("operation is required")
+        
+        if operation not in ['record', 'retrieve', 'search']:
+            raise ValueError("operation must be one of: record, retrieve, search")
+        
+        if operation == 'record' and not parameters.get('information'):
+            raise ValueError("information is required for record operation")
+        
+        if operation == 'search' and not parameters.get('search_query'):
+            raise ValueError("search_query is required for search operation")
+
+    def _invoke(self, tool_parameters: dict[str, Any]) -> Generator[ToolInvokeMessage]:
+        """
+        invoke tools
+        """
+        try:
+            # Debug: Log received parameters
+            logger.info(f"Received parameters: {list(tool_parameters.keys())}")
+            
+            # Check operation first
+            operation = tool_parameters.get("operation")
+            if not operation:
+                yield self.create_text_message("❌ Please select an operation (record/retrieve/search)")
+                return
+            
+            # Initialize Memory client if not already initialized
+            if not self.memory_client:
+                if not self._initialize_memory_client(tool_parameters):
+                    yield self.create_text_message("❌ Failed to initialize AgentCore Memory client")
+                    return
+
+            # Get required parameters
+            if not self.memory_id:
+                self.memory_id = tool_parameters.get("memory_id")
+                if not self.memory_id:
+                    yield self.create_text_message("❌ Please provide memory_id from AWS Console")
+                    return
+            
+            if not self.actor_id:
+                self.actor_id = tool_parameters.get("actor_id")
+                if not self.actor_id:
+                    yield self.create_text_message("❌ Please provide actor_id")
+                    return
+                
+            if not self.session_id:
+                self.session_id = tool_parameters.get("session_id")
+                if not self.session_id:
+                    yield self.create_text_message("❌ Please provide session_id")
+                    return
+                
+            # Namespace is only required for search
+            if operation == "search":
+                if not self.namespace:
+                    self.namespace = tool_parameters.get("namespace")
+                    if not self.namespace:
+                        yield self.create_text_message("❌ Please provide namespace for search operation")
+                        return
+            else:
+                # Set namespace for non-search operations if provided
+                if not self.namespace:
+                    self.namespace = tool_parameters.get("namespace")
+
+            # Route to appropriate operation
+            if operation == 'record':
+                yield from self._record_information(tool_parameters)
+            elif operation == 'retrieve':
+                yield from self._retrieve_history(tool_parameters)
+            elif operation == 'search':
+                yield from self._search_memories(tool_parameters)
+            else:
+                yield self.create_text_message(f"❌ Unknown operation: {operation}")
+
+        except Exception as e:
+            logger.error(f"Invoke error: {str(e)}", exc_info=True)
+            yield self.create_text_message(f"❌ Internal error: {str(e)}")

--- a/plugins/aws_tools/tools/agentcore_memory.yaml
+++ b/plugins/aws_tools/tools/agentcore_memory.yaml
@@ -1,0 +1,227 @@
+identity:
+  name: agentcore_memory
+  author: liniyuan
+  label:
+    en_US: AgentCore Memory
+    zh_Hans: AgentCore 记忆
+    pt_BR: Memória AgentCore
+  icon: icon.svg
+
+description:
+  human:
+    en_US: Unified AgentCore Memory tool for recording, retrieving, and searching memories
+    zh_Hans: 统一的 AgentCore 记忆工具，用于记录、检索和搜索记忆
+    pt_BR: Ferramenta unificada de memória AgentCore para gravar, recuperar e pesquisar memórias
+  llm: |
+    AGENTCORE MEMORY TOOL - Unified tool for all memory operations.
+    
+    OPERATIONS:
+    1. **RECORD** - Save new information to memory
+    2. **RETRIEVE** - Get conversation history (last K turns)
+    3. **SEARCH** - Find relevant memories by query
+    
+    WHEN TO USE:
+    - Record: User says "记录", "保存", "记住", "请记录"
+    - Retrieve: Need context from recent conversations
+    - Search: Looking for specific information from past interactions
+    
+    **Required Parameters**:
+    - memory_id: Get from AWS Console AgentCore Memory
+    - actor_id: Entity/user identifier
+    - session_id: Conversation session identifier
+    - namespace: Memory namespace (required for search)
+    
+    **Functions**:
+    - Record: client.create_event(memory_id, actor_id, session_id, messages)
+    - Retrieve: client.get_last_k_turns(memory_id, actor_id, session_id, k)
+    - Search: client.search(memory_id, query, max_results, actor_id, namespace)
+    
+    IMPORTANT: Always specify the operation parameter!
+
+parameters:
+  - name: aws_region
+    type: string
+    required: false
+    label:
+      en_US: AWS Region
+      zh_Hans: AWS区域
+      pt_BR: Região AWS
+    human_description:
+      en_US: AWS region for the AgentCore Memory service (optional)
+      zh_Hans: AgentCore Memory服务的AWS区域（可选）
+      pt_BR: Região AWS para o serviço AgentCore Memory (opcional)
+    llm_description: AWS region for the AgentCore Memory service.
+    form: form
+
+  - name: aws_access_key_id
+    type: string
+    required: false
+    label:
+      en_US: AWS Access Key ID
+      zh_Hans: AWS访问密钥ID
+      pt_BR: ID da Chave de Acesso AWS
+    human_description:
+      en_US: AWS access key ID for authentication (optional)
+      zh_Hans: 用于身份验证的AWS访问密钥ID（可选）
+      pt_BR: ID da chave de acesso AWS para autenticação (opcional)
+    llm_description: AWS access key ID for authentication.
+    form: form
+
+  - name: aws_secret_access_key
+    type: string
+    required: false
+    label:
+      en_US: AWS Secret Access Key
+      zh_Hans: AWS秘密访问密钥
+      pt_BR: Chave de Acesso Secreta AWS
+    human_description:
+      en_US: AWS secret access key for authentication (optional)
+      zh_Hans: 用于身份验证的AWS秘密访问密钥（可选）
+      pt_BR: Chave de acesso secreta AWS para autenticação (opcional)
+    llm_description: AWS secret access key for authentication.
+    form: form
+
+  - name: operation
+    type: select
+    required: true
+    options:
+      - value: record
+        label:
+          en_US: Record Information
+          zh_Hans: 记录信息
+          pt_BR: Gravar Informação
+      - value: retrieve
+        label:
+          en_US: Retrieve History
+          zh_Hans: 检索历史
+          pt_BR: Recuperar Histórico
+      - value: search
+        label:
+          en_US: Search Memories
+          zh_Hans: 搜索记忆
+          pt_BR: Pesquisar Memórias
+    label:
+      en_US: Operation
+      zh_Hans: 操作
+      pt_BR: Operação
+    human_description:
+      en_US: Select the memory operation to perform
+      zh_Hans: 选择要执行的记忆操作
+      pt_BR: Selecione a operação de memória a ser executada
+    llm_description: |
+      The type of memory operation to perform:
+      - "record": Save new information to memory
+      - "retrieve": Get recent conversation history
+      - "search": Find relevant memories by query
+    form: form
+
+  - name: information
+    type: string
+    required: false
+    label:
+      en_US: Information to Record
+      zh_Hans: 要记录的信息
+      pt_BR: Informação para Gravar
+    human_description:
+      en_US: The information to record (required for record operation)
+      zh_Hans: 要记录的信息（记录操作必需）
+      pt_BR: A informação a ser gravada (obrigatória para operação de gravação)
+    llm_description: |
+      The information that needs to be recorded. This should be the complete information
+      or important details that need to be stored for future reference.
+      Required when operation is "record".
+    form: llm
+
+  - name: search_query
+    type: string
+    required: false
+    label:
+      en_US: Search Query
+      zh_Hans: 搜索查询
+      pt_BR: Consulta de Pesquisa
+    human_description:
+      en_US: What you want to search for (required for search operation)
+      zh_Hans: 您想要搜索的内容（搜索操作必需）
+      pt_BR: O que você quer pesquisar (obrigatório para operação de pesquisa)
+    llm_description: |
+      The search query to find relevant memories. Use natural language to describe
+      what you're looking for. Required when operation is "search".
+    form: llm
+
+  - name: max_results
+    type: number
+    required: false
+    default: 10
+    label:
+      en_US: Maximum Results
+      zh_Hans: 最大结果数
+      pt_BR: Máximo de Resultados
+    human_description:
+      en_US: Maximum number of results to return (1-50 for retrieve, 1-20 for search)
+      zh_Hans: 返回的最大结果数量（检索1-50，搜索1-20）
+      pt_BR: Número máximo de resultados a retornar (1-50 para recuperar, 1-20 para pesquisar)
+    llm_description: |
+      Maximum number of results to return. 
+      For retrieve operation: 1-50 conversation turns (default 10)
+      For search operation: 1-20 memories (default 10)
+    form: llm
+
+  - name: memory_id
+    type: string
+    required: true
+    label:
+      en_US: Memory ID
+      zh_Hans: 记忆ID
+      pt_BR: ID da Memória
+    human_description:
+      en_US: ID of the memory resource (get from AWS Console)
+      zh_Hans: 记忆资源ID（从AWS控制台获取）
+      pt_BR: ID do recurso de memória (obter do Console AWS)
+    llm_description: The memory resource ID from AWS Console AgentCore Memory service.
+    form: form
+
+  - name: actor_id
+    type: string
+    required: true
+    label:
+      en_US: Actor ID
+      zh_Hans: 参与者ID
+      pt_BR: ID do Ator
+    human_description:
+      en_US: ID of the actor/entity (required)
+      zh_Hans: 参与者/实体ID（必填）
+      pt_BR: ID do ator/entidade (obrigatório)
+    llm_description: The actor ID for this memory operation.
+    form: form
+
+  - name: session_id
+    type: string
+    required: true
+    label:
+      en_US: Session ID
+      zh_Hans: 会话ID
+      pt_BR: ID da Sessão
+    human_description:
+      en_US: ID of the conversation session (required)
+      zh_Hans: 对话会话的ID（必填）
+      pt_BR: ID da sessão de conversa (obrigatório)
+    llm_description: The session ID for this conversation.
+    form: form
+
+  - name: namespace
+    type: string
+    required: false
+    label:
+      en_US: Namespace
+      zh_Hans: 命名空间
+      pt_BR: Namespace
+    human_description:
+      en_US: Memory namespace (required for search operation)
+      zh_Hans: 记忆命名空间（搜索操作必填）
+      pt_BR: Namespace da memória (obrigatório para operação de pesquisa)
+    llm_description: The memory namespace for search operation.
+    form: form
+
+extra:
+  python:
+    source: tools/agentcore_memory.py


### PR DESCRIPTION
This PR adds a new AgentCore Memory tool to the AWS tools collection.

### Files Added
- `plugins/aws_tools/tools/agentcore_memory.py` - Main tool implementation
- `plugins/aws_tools/tools/agentcore_memory.yaml` - Tool configuration

### Features
- **Record**: Save information to memory
- **Retrieve**: Get conversation history  
- **Search**: Find relevant memories
- Consistent AWS credential handling with existing tools

### Dependencies
- bedrock-agentcore SDK
- boto3 (already used by other tools)

### Testing
- Tested all three operations (record/retrieve/search)
- Verified AWS credential handling
- Confirmed parameter validation