### PR TITLE
fix: add extra logic for coherent rerank in BedrockRerankModel

### DIFF
--- a/plugins/bedrock/models/rerank/rerank.py
+++ b/plugins/bedrock/models/rerank/rerank.py
@@ -97,10 +97,16 @@ class BedrockRerankModel(RerankModel):
 
         numberOfResults = min(len(text_sources) if top_n is None else top_n, len(text_sources))
 
-        body = json.dumps({
+        body_dict = {
             "query": query,
             "documents": docs
-        })
+        }
+
+        # Only add api_version for Cohere models
+        if "cohere" in model_id.lower():
+            body_dict["api_version"] = 2
+        
+        body = json.dumps(body_dict)
     
         response = bedrock_runtime.invoke_model(
             modelId=model_package_arn,


### PR DESCRIPTION
*Issue #, if available:*

It's impossible to add custom rerank model from bedrock into aws tool plugin in dify with either app inference profile or FM ARN.

We will encounter this exception upone saving [models] Error: An error occurred (ValidationException) when calling the Rerank operation: The provided model ARN for reranking is invalid. Please, use a valid model ARN. Also check the model ARN follows this format: arn:<partition>:bedrock:<region>:<foundation-model/<model-id>

*Description of changes:*

Change the bedrock_runtime.rerank to bedrock_runtime.invoke_model to fix the issue

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
