### PR TITLE
fixing model_id issue

### DIFF
--- a/plugins/bedrock/models/text_embedding/text_embedding.py
+++ b/plugins/bedrock/models/text_embedding/text_embedding.py
@@ -74,6 +74,8 @@ class BedrockTextEmbeddingModel(TextEmbeddingModel):
                 if "foundation-model/" in first_model_arn:
                     underlying_model_id = first_model_arn.split("foundation-model/")[1]
                     model_prefix = underlying_model_id.split(".")[0]
+                    # Update model_id to the actual foundation model ARN
+                    model_id = underlying_model_id
                 else:
                     raise InvokeError(f"Could not determine model type from inference profile")
             else:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

In the previous code, the model_id is taken from model name that cx entered. so if the model name doesnt contain the name of the model like titan, it would still not be able to find model name, hence the best is to get model_id from underlying_model_id. its the safest


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
