### PR TITLE
fix: handle missing auth_method in validate_credentials for customiza…

### DIFF
--- a/plugins/bedrock/models/llm/llm.py
+++ b/plugins/bedrock/models/llm/llm.py
@@ -1087,22 +1087,22 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
         :param credentials: model credentials
         :return:
         """
-        if 'auth_method' not in credentials:
-            raise CredentialsValidateFailedError("Authentication method 'auth_method' is missing in credentials.")
-
         try:
-            if credentials['auth_method'] == 'IAM_Role':
+            # Check if this is an inference profile based custom model
+            inference_profile_id = credentials.get("inference_profile_id")
+            if inference_profile_id:
+                # Validate inference profile directly
+                validate_inference_profile(inference_profile_id, credentials)
+                logger.info(f"Successfully validated inference profile: {inference_profile_id}")
                 return
-            elif credentials['auth_method'] == 'Access_Secret_Key':
-                if credentials['aws_access_key_id'] and credentials['aws_secret_access_key']:
-                    return 
-            elif credentials['auth_method'] == 'API_Key':
-                if credentials['bedrock_api_key']:
-                    return
-
-            raise CredentialsValidateFailedError(f"Invalid or incomplete credentials for auth_method: {credentials.get('auth_method')}")
+            
+            # Traditional model validation - just try to get bedrock client
+            bedrock_client = get_bedrock_client("bedrock-runtime", credentials)
+            # Just getting the client validates the credentials
+            logger.info(f"Successfully validated model: {model}")
         except Exception as ex:
             raise CredentialsValidateFailedError(str(ex))
+
 
     def _list_foundation_models(self, credentials: dict) -> list[str]:
         """

--- a/plugins/bedrock/models/rerank/rerank.py
+++ b/plugins/bedrock/models/rerank/rerank.py
@@ -87,6 +87,19 @@ class BedrockRerankModel(RerankModel):
             if not model_package_arn:
                 raise InvokeError(f"Could not get ARN for inference profile {inference_profile_id}")
             logger.info(f"Using inference profile ARN: {model_package_arn}")
+
+            # Determine model prefix from underlying models
+            underlying_models = profile_info.get("models", [])
+            if underlying_models:
+                first_model_arn = underlying_models[0].get("modelArn", "")
+                if "foundation-model/" in first_model_arn:
+                    underlying_model_id = first_model_arn.split("foundation-model/")[1]
+                    # Update model_id to the actual foundation model ARN
+                    model_id = underlying_model_id
+                else:
+                    raise InvokeError(f"Could not determine model type from inference profile")
+            else:
+                raise InvokeError(f"No underlying models found in inference profile")
         else:
             # Traditional model - build ARN
             region = credentials.get("aws_region")


### PR DESCRIPTION
…ble models

*Issue #, if available:*

*Description of changes:*

Two fixes

1. llm when import llm into dify bedrock plugin, it would fail because UI doesnt have auth_method field any more hence we need another way to validate the inference profile like getting inference profile and fallback to getbedrockclient
2. when importing rerank model into dify, the model name must equal to the name of the model, we couldnt customize the name, now we can give it a customized name


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
