### PR TITLE
fix: use UserPromptMessage instead of AssistantPromptMessage for resp…

### DIFF
--- a/plugins/bedrock/models/llm/llm.py
+++ b/plugins/bedrock/models/llm/llm.py
@@ -140,7 +140,7 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
                 prompt_messages[0] = format_prompt
             else:
                 prompt_messages.insert(0, format_prompt)
-            prompt_messages.append(AssistantPromptMessage(content=f"\n```{response_format}"))
+            prompt_messages.append(UserPromptMessage(content=f"Output ```{response_format} block only."))
         return self._invoke(model, credentials, prompt_messages, model_parameters, tools, stop, stream, user)
 
     def _invoke(
@@ -203,7 +203,7 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
                                 prompt_messages[0] = format_prompt
                             else:
                                 prompt_messages.insert(0, format_prompt)
-                            prompt_messages.append(AssistantPromptMessage(content=f"\n```{response_format}"))
+                            prompt_messages.append(UserPromptMessage(content=f"Output ```{response_format} block only."))
                         else:
                             # For non-Anthropic models, just remove response_format parameter
                             model_parameters.pop("response_format", None)


### PR DESCRIPTION
…onse_format hint

*Issue #, if available:*

fixing this issue https://github.com/langgenius/dify-official-plugins/issues/2824 

*Description of changes:*

Since AWS bedrock converse API doesn't support prefill (dify has a feature to set structured output in such format like json), we will need to replace the assistance message with user message and i have tested it with claude opus 4.6 which works perfectly fine with the user message but again for some other LLM, the json format may not always be enforced. 

The real fix is to add in the nre structured output https://docs.aws.amazon.com/bedrock/latest/userguide/structured-output.html  to the existing code but it requires a lot of code change as well as boto3 upgrade which requires thorough test before release

Hence, the short fix which can unblock our user quickly is to replace assistance message with user message first.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
